### PR TITLE
Fix link in basics TOC to sumstruct

### DIFF
--- a/doc/tutorial/basics/Readme.md
+++ b/doc/tutorial/basics/Readme.md
@@ -37,7 +37,7 @@ Use the `cue eval` or `cue export` commands to evaluate an example.
   - [Order is Irrelevant](unification.md)
   - [Disjunctions](disjunctions.md)
   - [Default Values](defaults.md)
-  - [Disjunctions of Structs](disjstruct.md)
+  - [Disjunctions of Structs](sumstruct.md)
   - [Numbers](numbers.md)
   - [Ranges](ranges.md)
   - [Predefined Ranges](rangedef.md)


### PR DESCRIPTION
This link seems broken.