### PR TITLE
Update docs - you need Go 1.12

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -6,7 +6,7 @@ Currently CUE can only be installed from source.
 
 ### Prerequisites
 
-Go 1.10 or higher (see below)
+Go 1.12 or higher (see below)
 
 ### Installing CUE
 


### PR DESCRIPTION
With Go 1.10 I get the following error:
```
cmd/common.go:54:7: undefined: bytes.ReplaceAll
```