### PR TITLE
Document that Go 1.12 is needed

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -6,7 +6,7 @@ Currently CUE can only be installed from source.
 
 ### Prerequisites
 
-Go 1.10 or higher (see below)
+Go 1.12 or higher (see below)
 
 ### Installing CUE
 


### PR DESCRIPTION
cue uses `bytes.ReplaceAll` which is a method that was added in 1.12 -> Go 1.12 is needed.