### PR TITLE
all: add homebrew config to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,3 +54,12 @@ changelog:
   filters:
     exclude:
     - '^test:'
+
+brews:
+- github:
+    owner: cuelang 
+    name: homebrew-tap
+  homepage: "https://github.com/cuelang/cue"
+  description: "CUE is an open source data constraint language which aims to simplify tasks involving defining and using data."
+  test: |
+    system "#{bin}/cue version"


### PR DESCRIPTION
This commit adds a `brews` stanza to the goreleaser config, creating and updating a homebrew tap for the `cue` binary distribution. 

Note: This assumes that `https://github.com/cuelang/homebrew-tap` exists and can be pushed to from the CI tooling. The mechanics of that integration are a bit unclear in the `goreleaser` docs. 

One potential addition:
```
  commit_author:
    name: cuebot
    email: gitbot@cuelang.org
``` 
Or something similar to this. 

I tried to test this locally, but was unable to...