### PR TITLE
cue/load: implement package name qualifiers

### DIFF
--- a/cue/build/import.go
+++ b/cue/build/import.go
@@ -103,7 +103,7 @@ func (inst *Instance) complete() errors.Error {
 					continue
 				}
 				if imp.Err != nil {
-					return nil
+					return imp.Err
 				}
 				imp.ImportPath = path
 				// imp.parent = inst

--- a/cue/errors/errors.go
+++ b/cue/errors/errors.go
@@ -239,6 +239,24 @@ func appendToList(a list, err Error) list {
 // The zero value for an list is an empty list ready to use.
 type list []Error
 
+func (p list) Is(err, target error) bool {
+	for _, e := range p {
+		if xerrors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p list) As(err error, target interface{}) bool {
+	for _, e := range p {
+		if xerrors.As(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
 // AddNewf adds an Error with given position and error message to an List.
 func (p *list) AddNewf(pos token.Pos, msg string, args ...interface{}) {
 	err := &posError{pos: pos, Message: Message{format: msg, args: args}}

--- a/cue/load/fs.go
+++ b/cue/load/fs.go
@@ -68,10 +68,6 @@ func (fs *fileSystem) init(c *Config) error {
 
 	// Organize overlay
 	for filename, src := range overlay {
-		if !strings.HasSuffix(filename, ".cue") {
-			return errors.Newf(token.NoPos, "overlay file %s not a .cue file", filename)
-		}
-
 		// TODO: do we need to further clean the path or check that the
 		// specified files are within the root/ absolute files?
 		dir, base := filepath.Split(filename)

--- a/cue/load/testdata/pkg/acme.com/catch/catch.cue
+++ b/cue/load/testdata/pkg/acme.com/catch/catch.cue
@@ -1,5 +1,5 @@
 package catch
 
-import "acme.com/helper"
+import "acme.com/helper:helper1"
 
 Method: "tnt" | "catapult" | "net" | helper.Gotcha

--- a/cue/load/testdata/pkg/acme.com/helper/helper1.cue
+++ b/cue/load/testdata/pkg/acme.com/helper/helper1.cue
@@ -1,0 +1,3 @@
+package helper1
+
+Gotcha: "gotcha"

--- a/cue/load/testdata/pkg/acme.com/helper/helper2.cue
+++ b/cue/load/testdata/pkg/acme.com/helper/helper2.cue
@@ -1,0 +1,3 @@
+package helper2
+
+Gotcha: "gotcha"

--- a/cue/parser/parser.go
+++ b/cue/parser/parser.go
@@ -1221,6 +1221,9 @@ func (p *parser) parseRHS() ast.Expr {
 func isValidImport(lit string) bool {
 	const illegalChars = `!"#$%&'()*,:;<=>?[\]^{|}` + "`\uFFFD"
 	s, _ := literal.Unquote(lit) // go/scanner returns a legal string literal
+	if p := strings.LastIndexByte(s, ':'); p >= 0 {
+		s = s[:p]
+	}
 	for _, r := range s {
 		if !unicode.IsGraphic(r) || unicode.IsSpace(r) || strings.ContainsRune(illegalChars, r) {
 			return false


### PR DESCRIPTION
Implements the spec.
The package name of imported files now _must_ be
included in the import path. If it it doesn't match
the last path component of the import path, it can
be modified with a :<name> at the end.