### PR TITLE
Hide conn (with underscore) OR Define conn as a Definition:: ?

### DIFF
--- a/doc/tutorial/basics/disjunctions.md
+++ b/doc/tutorial/basics/disjunctions.md
@@ -13,13 +13,13 @@ to define anything else than these two values.
 
 <!-- CUE editor -->
 ```
-conn: {
+_conn: {
     address:  string
     port:     int
     protocol: "tcp" | "udp"
 }
 
-lossy: conn & {
+lossy: _conn & {
     address:  "1.2.3.4"
     port:     8888
     protocol: "udp"


### PR DESCRIPTION
Shouldn't this example hide conn to avoid an error (cue: marshal error at path conn.address: cannot convert incomplete value "string" to JSON) when exporting (Or better yet, specify conn:: as a definition)? 