### PR TITLE
cmd/cue: fix tests under different platforms

### DIFF
--- a/cmd/cue/cmd/script_test.go
+++ b/cmd/cue/cmd/script_test.go
@@ -15,6 +15,10 @@ func TestScript(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	// Setting inTest causes filenames printed in error messages
+	// to be normalized so the output looks the same on Unix
+	// as Windows.
+	inTest = true
 	os.Exit(testscript.RunMain(m, map[string]func() int{
 		"cue": Main,
 	}))

--- a/cmd/cue/cmd/testdata/script/cmd_errcode.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_errcode.txt
@@ -1,9 +1,7 @@
 ! cue cmd errcode
 ! stdout .
-cmp stderr cmd_baddisplay.out
+stderr '^command "ls --badflags" failed: exit status [12]$'
 
--- cmd_baddisplay.out --
-command "ls --badflags" failed: exit status 2
 -- task.cue --
 package home
 message: "Hello world!"


### PR DESCRIPTION
Normalize filenames under Windows.
Copy with the fact that `ls` returns different status codes in different platforms.

Change-Id: I689fc08c152fc84190444171fee70d2bbb258ba5