### PR TITLE
start using GitHub Actions as CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# To prevent CRLF breakages on Windows for fragile files, like testdata.
+* -text

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+on: [push, pull_request]
+name: Test
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.12.x, 1.13.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v1
+
+    - name: Test
+      run: go test ./...
+    - name: Test with -race
+      run: go test -race ./...

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
  limitations under the License.
 -->
 [![GoDoc](https://godoc.org/cuelang.org/go?status.svg)](https://godoc.org/cuelang.org/go)
-[![Appveyor](https://ci.appveyor.com/api/projects/status/0v3ec7p5162hpwpe?svg=true)](https://ci.appveyor.com/project/mpvl/cue)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cuelang/cue)](https://goreportcard.com/report/github.com/cuelang/cue)
 [![Go 1.12](https://img.shields.io/badge/go-1.12-9cf.svg)](https://golang.org/dl/)
 [![platforms](https://img.shields.io/badge/platforms-linux|windows|macos-inactive.svg)]()

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,0 @@
-steps:
-- name: golang:1.12
-  env: ['GO111MODULE=on']
-  args: ['go', 'test', './...', '-race' ]

--- a/cmd/cue/cmd/testdata/script/cmd_echo.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_echo.txt
@@ -1,7 +1,5 @@
 cue cmd echo
-cmp stdout expect-stdout
--- expect-stdout --
-Hello World!
+stdout 'Hello World!'
 
 -- data.cue --
 package hello

--- a/cmd/cue/cmd/testdata/script/cmd_run.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_run.txt
@@ -1,8 +1,5 @@
 cue cmd run
-cmp stdout run.out
-
--- run.out --
-Hello world!
+stdout 'Hello world!'
 
 -- task.cue --
 package home

--- a/cmd/cue/cmd/testdata/script/cmd_run_list.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_run_list.txt
@@ -1,8 +1,5 @@
 cue cmd run_list
-cmp stdout run_list.out
-
--- run_list.out --
-Hello world!
+stdout 'Hello world!'
 
 -- task.cue --
 package home


### PR DESCRIPTION
For now, this tests on Ubuntu, MacOS, and Windows, both on the latest Go
1.12 and 1.13. We run the tests both with and without -race.

Three tests needed updating, since they exec the system's "echo" binary.
On Windows, that may use CRLF line endings, which happened on GitHub
Actions. To fix that, match the output with a line regular expression,
instead of via an entire stdout file with LF line endings.

Finally, remove the AppVeyor badge and cloudbuild file, as we won't be
needing those anymore.

Fixes #144.