### PR TITLE
cmd/cue/cmd: add MainTest

### DIFF
--- a/cmd/cue/cmd/common.go
+++ b/cmd/cue/cmd/common.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"bytes"
-	"flag"
 	"io"
 	"os"
 	"strings"
@@ -34,12 +33,6 @@ import (
 var runtime = &cue.Runtime{}
 
 var inTest = false
-
-func init() {
-	if flag.Lookup("test.v") != nil || strings.Contains(os.Args[0], "/_test/") {
-		inTest = true
-	}
-}
 
 func mustParseFlags(t *testing.T, cmd *cobra.Command, flags ...string) {
 	if err := cmd.ParseFlags(flags); err != nil {

--- a/cmd/cue/cmd/root.go
+++ b/cmd/cue/cmd/root.go
@@ -102,6 +102,12 @@ For more information on writing CUE configuration files see cuelang.org.`,
 	return c
 }
 
+// MainTest is like Main, runs the cue tool and returns the code for passing to os.Exit.
+func MainTest() int {
+	inTest = true
+	return Main()
+}
+
 // Main runs the cue tool and returns the code for passing to os.Exit.
 func Main() int {
 	err := mainErr(context.Background(), os.Args[1:])

--- a/cmd/cue/cmd/script_test.go
+++ b/cmd/cue/cmd/script_test.go
@@ -18,8 +18,7 @@ func TestMain(m *testing.M) {
 	// Setting inTest causes filenames printed in error messages
 	// to be normalized so the output looks the same on Unix
 	// as Windows.
-	inTest = true
 	os.Exit(testscript.RunMain(m, map[string]func() int{
-		"cue": Main,
+		"cue": MainTest,
 	}))
 }

--- a/doc/tutorial/basics/intro/32_validation.txt
+++ b/doc/tutorial/basics/intro/32_validation.txt
@@ -1,4 +1,5 @@
 ! cue vet schema.cue data.yaml
+cmp stderr expect-stderr
 
 -- frontmatter.toml --
 title = "Validation"

--- a/doc/tutorial/basics/script_test.go
+++ b/doc/tutorial/basics/script_test.go
@@ -27,6 +27,6 @@ func TestScript(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	os.Exit(testscript.RunMain(m, map[string]func() int{
-		"cue": cmd.Main,
+		"cue": cmd.MainTest,
 	}))
 }


### PR DESCRIPTION
Add separate MainTest to avoid having to expose inTest.

This allows testScript-like usage outside of cmd/cue/cmd.

Note that auto-detecting tests, although working fine
on AppVeyor, does not work on Github. This is much
better anyway.