### PR TITLE
describe the `go get` step before `cue get go` in the tutorial

### DIFF
--- a/doc/tutorial/kubernetes/README.md
+++ b/doc/tutorial/kubernetes/README.md
@@ -1050,6 +1050,14 @@ of course.
 
 ### Extract CUE templates directly from Kubernetes Go source
 
+In order for `cue get go` to generate the CUE templates from Go sources, you first need to have the sources locally:
+
+```
+$ go get k8s.io/api/apps/v1
+$ go get k8s.io/api/extensions/v1beta1
+$ go get k8s.io/api/apps/v1beta1
+```
+
 ```
 $ cue get go k8s.io/api/core/v1
 $ cue get go k8s.io/api/extensions/v1beta1


### PR DESCRIPTION
see #95.  Still needs to be done for the docs in cuelang.org website.