### PR TITLE
Decode null as NULL token in yaml decoder

### DIFF
--- a/internal/third_party/yaml/decode.go
+++ b/internal/third_party/yaml/decode.go
@@ -443,7 +443,11 @@ func (d *decoder) scalar(n *node) ast.Expr {
 		}
 	}
 	if resolved == nil {
-		return d.ident(n, "null")
+		return &ast.BasicLit{
+			ValuePos: d.start(n),
+			Kind:     token.NULL,
+			Value:    "null",
+		}
 	}
 	switch tag {
 	// TODO: use parse literal or parse expression instead.


### PR DESCRIPTION
This PR will fix #185 as `BasicLit` will be returned for null value.

When we walk through the ast to create the instance, null value will be handled as `BasicLit` instead of `Ident`.