### PR TITLE
internal/yaml: import null value properly

### DIFF
--- a/internal/third_party/yaml/decode.go
+++ b/internal/third_party/yaml/decode.go
@@ -395,6 +395,9 @@ func (d *decoder) absPos(m yaml_mark_t) token.Pos {
 }
 
 func (d *decoder) start(n *node) token.Pos {
+	if n.startPos == n.endPos {
+		return token.NoPos
+	}
 	return d.pos(n.startPos)
 }
 
@@ -444,7 +447,7 @@ func (d *decoder) scalar(n *node) ast.Expr {
 	}
 	if resolved == nil {
 		return &ast.BasicLit{
-			ValuePos: d.start(n),
+			ValuePos: d.start(n).WithRel(token.Blank),
 			Kind:     token.NULL,
 			Value:    "null",
 		}
@@ -517,7 +520,7 @@ func (d *decoder) scalar(n *node) ast.Expr {
 
 	case yaml_NULL_TAG:
 		return &ast.BasicLit{
-			ValuePos: d.start(n),
+			ValuePos: d.start(n).WithRel(token.Blank),
 			Kind:     token.NULL,
 			Value:    "null",
 		}

--- a/internal/third_party/yaml/decode_test.go
+++ b/internal/third_party/yaml/decode_test.go
@@ -153,6 +153,11 @@ var unmarshalTests = []struct {
 	}, {
 		"~: null key",
 		`"~": "null key"`,
+	}, {
+		`empty:
+apple: "newline"`,
+		`empty: null
+apple: "newline"`,
 	},
 
 	// Flow sequence


### PR DESCRIPTION
When import this yaml file:

```
a:
b: c
```

We'll get

```
a:
        null, b: "c"
```

Because we don't handle null value which take no space correctly. The `ValuePos` of the null value is `Newline` instead of `Blank` and the the `ValuePos` of field `b` is `Blank` instead of `Newline`

This PR properly set `ValuePos` to `NoPos` + `Blank` for null value.