### PR TITLE
cmd/cue/cmd: control task dependency using before and after fields

### DIFF
--- a/cmd/cue/cmd/testdata/script/cmd_after.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_after.txt
@@ -1,0 +1,40 @@
+cue cmd after
+cmp stdout expect-stdout
+
+-- expect-stdout --
+true
+
+-- after_tool.cue --
+package home
+
+import (
+	"tool/exec"
+	"tool/cli"
+	"strings"
+)
+
+command: after: {
+	task: {
+		t1: exec.Run & {
+			cmd: ["sh", "-c", "sleep 2; date +%s"]
+			stdout: string
+		}
+		t2: exec.Run & {
+			cmd: ["sh", "-c", "date +%s"]
+			stdout: string
+			$after: task.t1
+		}
+		t3: exec.Run & {
+			cmd: ["sh", "-c", "a=\(strings.TrimSpace(task.t1.stdout));b=\(strings.TrimSpace(task.t2.stdout));if [ $a -le $b ]; then echo 'true'; fi"]
+			stdout: string
+		}
+		t4: cli.Print & {
+				text: task.t3.stdout
+		}
+	}
+}
+
+-- task.cue --
+package home
+
+-- cue.mod --

--- a/cmd/cue/cmd/testdata/script/cmd_before.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_before.txt
@@ -1,0 +1,45 @@
+cue cmd before
+cmp stdout expect-stdout
+
+-- expect-stdout --
+true
+
+-- before_tool.cue --
+package home
+
+import (
+	"tool/exec"
+	"tool/cli"
+	"strings"
+)
+
+command: before: {
+	task: {
+		t1: exec.Run & {
+			cmd: ["sh", "-c", "sleep 2; date +%s"]
+			stdout: string
+			$before: [task.t2, task.t3]
+		}
+		t2: exec.Run & {
+			cmd: ["sh", "-c", "date +%s"]
+			stdout: string
+			$before: task.t4
+		}
+		t3: exec.Run & {
+			cmd: ["sh", "-c", "date +%s"]
+			stdout: string
+		}
+		t4: exec.Run & {
+			cmd: ["sh", "-c", "a=\(strings.TrimSpace(task.t1.stdout));b=\(strings.TrimSpace(task.t2.stdout));if [ $a -le $b ]; then echo 'true'; fi"]
+			stdout: string
+		}
+		t5: cli.Print & {
+				text: task.t4.stdout
+		}
+	}
+}
+
+-- task.cue --
+package home
+
+-- cue.mod --

--- a/cmd/cue/cmd/testdata/script/cmd_ref.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_ref.txt
@@ -1,0 +1,29 @@
+cue cmd ref
+cmp stdout expect-stdout
+
+-- expect-stdout --
+hello
+
+-- task_tool.cue --
+package home
+
+import (
+	"tool/cli"
+)
+
+command: ref: {
+	task: {
+		t1: exec.Run & {
+				ref: task.t1.stdout
+				cmd: ["sh", "-c", "echo hello"]
+				stdout: string
+		}
+		t2: cli.Print & {
+			text: task.t1.stdout
+		}
+	}
+}
+
+-- task.cue --
+package home
+-- cue.mod --


### PR DESCRIPTION
Currently we resolve task dependency by checking reference to incomplete task variable. We cannot do things like `create a file first, then run a command with it`.

For example this command would not work cause `write` and `ansible` will be executed at the same time.

```
command: play: {
	task: write: file.Create & {
		filename: "playbook.yml"
		contents:  yaml.MarshalStream([playbook])
	}
	task: ansible: exec.Run & {
		cmd:    "ansible-playbook playbook.yml"
		stdout: string
	}
	task: display: cli.Print & {
		text: task.ansible.stdout
	}
}
```

Using this PR, we could declare dependency and reverse dependency using `before` and `after` fields. The value could be either a task or a list of tasks. Now we can rewrite the command like this to make it work.

```
command: play: {
	task: write: file.Create & {
		filename: "playbook.yml"
		contents:  yaml.MarshalStream([playbook])
	}
	task: ansible: exec.Run & {
		cmd:    "ansible-playbook playbook.yml"
		stdout: string
		after: task.write
	}
	task: display: cli.Print & {
		text: task.ansible.stdout
	}
}
```

