### PR TITLE
doc: fix typos in language spec

### DIFF
--- a/doc/ref/spec.md
+++ b/doc/ref/spec.md
@@ -2636,10 +2636,12 @@ The built-in function `and` takes a list and returns the result of applying
 the `&` operator to all elements in the list.
 It returns top for the empty list.
 
+```
 Expression:          Result
 and([a, b])          a & b
 and([a])             a
 and([])              _
+```
 
 ### `or`
 
@@ -2649,9 +2651,9 @@ It returns bottom for the empty list.
 
 ```
 Expression:          Result
-and([a, b])          a | b
-and([a])             a
-and([])              _|_
+or([a, b])           a | b
+or([a])              a
+or([])               _|_
 ```
 
 


### PR DESCRIPTION
Found it while reading the spec for builtin functions.