### PR TITLE
cmd/cue/cmd: cleanup std{in,out,err} handling with context based approach

### DIFF
--- a/cmd/cue/cmd/cmd.go
+++ b/cmd/cue/cmd/cmd.go
@@ -15,15 +15,17 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"cuelang.org/go/internal/ctxio"
 	"github.com/spf13/cobra"
 )
 
 // TODO: generate long description from documentation.
 
-func newCmdCmd(c *Command) *cobra.Command {
+func newCmdCmd(ctx context.Context, c *Command) *cobra.Command {
 	return &cobra.Command{
 		Use:   "cmd <name> [-x] [instances]",
 		Short: "run a user-defined shell command",
@@ -216,8 +218,8 @@ An example using pipes:
 	}
 
 `,
-		RunE: mkRunE(c, func(cmd *Command, args []string) error {
-			w := cmd.Stderr()
+		RunE: mkRunE(ctx, c, func(ctx context.Context, cmd *Command, args []string) error {
+			w := ctxio.Stderr(ctx)
 			if len(args) == 0 {
 				fmt.Fprintln(w, "cmd must be run as one of its subcommands")
 			} else {

--- a/cmd/cue/cmd/eval.go
+++ b/cmd/cue/cmd/eval.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"cuelang.org/go/cue"
@@ -26,7 +27,7 @@ import (
 )
 
 // newEvalCmd creates a new eval command
-func newEvalCmd(c *Command) *cobra.Command {
+func newEvalCmd(ctx context.Context, c *Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "eval",
 		Short: "evaluate and print a configuration",
@@ -47,7 +48,7 @@ Examples:
   "a"
   "c"
 `,
-		RunE: mkRunE(c, runEval),
+		RunE: mkRunE(ctx, c, runEval),
 	}
 
 	cmd.Flags().StringArrayP(string(flagExpression), "e", nil, "evaluate this expression only")
@@ -78,8 +79,8 @@ const (
 	flagAttributes flagName = "attributes"
 )
 
-func runEval(cmd *Command, args []string) error {
-	instances := buildFromArgs(cmd, args)
+func runEval(ctx context.Context, cmd *Command, args []string) error {
+	instances := buildFromArgs(ctx, cmd, args)
 
 	var exprs []ast.Expr
 	for _, e := range flagExpression.StringArray(cmd) {
@@ -127,7 +128,7 @@ func runEval(cmd *Command, args []string) error {
 			v := inst.Value()
 			if flagConcrete.Bool(cmd) && !flagIgnore.Bool(cmd) {
 				if err := v.Validate(cue.Concrete(true)); err != nil {
-					exitIfErr(cmd, inst, err, false)
+					exitIfErr(ctx, inst, err, false)
 					continue
 				}
 			}
@@ -141,7 +142,7 @@ func runEval(cmd *Command, args []string) error {
 			v := inst.Eval(e)
 			if flagConcrete.Bool(cmd) && !flagIgnore.Bool(cmd) {
 				if err := v.Validate(cue.Concrete(true)); err != nil {
-					exitIfErr(cmd, inst, err, false)
+					exitIfErr(ctx, inst, err, false)
 					continue
 				}
 			}

--- a/cmd/cue/cmd/export.go
+++ b/cmd/cue/cmd/export.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +26,7 @@ import (
 )
 
 // newExportCmd creates and export command
-func newExportCmd(c *Command) *cobra.Command {
+func newExportCmd(ctx context.Context, c *Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "output data in a standard format",
@@ -87,7 +88,7 @@ text    output as raw text
         The evaluated value must be of type string.
 `,
 
-		RunE: mkRunE(c, runExport),
+		RunE: mkRunE(ctx, c, runExport),
 	}
 	flagMedia.Add(cmd)
 	cmd.Flags().Bool(string(flagEscape), false, "use HTML escaping")
@@ -95,8 +96,8 @@ text    output as raw text
 	return cmd
 }
 
-func runExport(cmd *Command, args []string) error {
-	instances := buildFromArgs(cmd, args)
+func runExport(ctx context.Context, cmd *Command, args []string) error {
+	instances := buildFromArgs(ctx, cmd, args)
 	w := cmd.OutOrStdout()
 
 	for _, inst := range instances {
@@ -104,13 +105,13 @@ func runExport(cmd *Command, args []string) error {
 		switch media := flagMedia.String(cmd); media {
 		case "json":
 			err := outputJSON(cmd, w, root)
-			exitIfErr(cmd, inst, err, true)
+			exitIfErr(ctx, inst, err, true)
 		case "text":
 			err := outputText(w, root)
-			exitIfErr(cmd, inst, err, true)
+			exitIfErr(ctx, inst, err, true)
 		case "yaml":
 			err := outputYAML(w, root)
-			exitIfErr(cmd, inst, err, true)
+			exitIfErr(ctx, inst, err, true)
 		default:
 			return fmt.Errorf("export: unknown format %q", media)
 		}

--- a/cmd/cue/cmd/fmt.go
+++ b/cmd/cue/cmd/fmt.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"io/ioutil"
 	"os"
+	"context"
 
 	"cuelang.org/go/cue/format"
 	"cuelang.org/go/cue/load"
@@ -24,16 +25,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newFmtCmd(c *Command) *cobra.Command {
+func newFmtCmd(ctx context.Context, c *Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fmt [-s] [packages]",
 		Short: "formats CUE configuration files",
 		Long: `Fmt formats the given files or the files for the given packages in place
 `,
-		RunE: mkRunE(c, func(cmd *Command, args []string) error {
+		RunE: mkRunE(ctx, c, func(ctx context.Context, cmd *Command, args []string) error {
 			for _, inst := range load.Instances(args, nil) {
 				if inst.Err != nil {
-					exitOnErr(cmd, inst.Err, false)
+					exitOnErr(ctx, inst.Err, false)
 					continue
 				}
 				all := []string{}

--- a/cmd/cue/cmd/get.go
+++ b/cmd/cue/cmd/get.go
@@ -15,13 +15,15 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"cuelang.org/go/internal/ctxio"
 	"github.com/spf13/cobra"
 )
 
-func newGetCmd(c *Command) *cobra.Command {
+func newGetCmd(ctx context.Context, c *Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <language> [packages]",
 		Short: "add dependencies to the current module",
@@ -35,8 +37,8 @@ the source of the respective language and stored.
 The specifics on how dependencies are fechted and converted vary
 per language and are documented in the respective subcommands.
 `,
-		RunE: mkRunE(c, func(cmd *Command, args []string) error {
-			stderr := cmd.Stderr()
+		RunE: mkRunE(ctx, c, func(ctx context.Context, cmd *Command, args []string) error {
+			stderr := ctxio.Stderr(ctx)
 			if len(args) == 0 {
 				fmt.Fprintln(stderr, "get must be run as one of its subcommands")
 			} else {
@@ -47,6 +49,6 @@ per language and are documented in the respective subcommands.
 			return nil
 		}),
 	}
-	cmd.AddCommand(newGoCmd(c))
+	cmd.AddCommand(newGoCmd(ctx, c))
 	return cmd
 }

--- a/cmd/cue/cmd/get_go_test.go
+++ b/cmd/cue/cmd/get_go_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -38,7 +39,8 @@ func TestGetGo(t *testing.T) {
 	cueTestRoot = tmp
 
 	// We don't use runCommand here, as we are interested in generated packages.
-	cmd := newGoCmd(newRootCmd())
+	ctx := context.Background()
+	cmd := newGoCmd(ctx, newRootCmd(ctx))
 	cmd.SetArgs([]string{"./testdata/code/go/..."})
 	err = cmd.Execute()
 	if err != nil {

--- a/cmd/cue/cmd/import.go
+++ b/cmd/cue/cmd/import.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -43,7 +44,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func newImportCmd(c *Command) *cobra.Command {
+func newImportCmd(ctx context.Context, c *Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import",
 		Short: "convert other data formats to CUE files",
@@ -194,7 +195,7 @@ Example:
       }
   }
 `,
-		RunE: mkRunE(c, runImport),
+		RunE: mkRunE(ctx, c, runImport),
 	}
 
 	flagOut.Add(cmd)
@@ -251,7 +252,7 @@ func getExtInfo(ext string) *encodingInfo {
 	return nil
 }
 
-func runImport(cmd *Command, args []string) error {
+func runImport(ctx context.Context, cmd *Command, args []string) error {
 	var group errgroup.Group
 
 	pkgFlag := flagPackage.String(cmd)
@@ -302,7 +303,7 @@ func runImport(cmd *Command, args []string) error {
 	})
 
 	err := group.Wait()
-	exitOnErr(cmd, err, true)
+	exitOnErr(ctx, err, true)
 	return nil
 }
 

--- a/cmd/cue/cmd/root_test.go
+++ b/cmd/cue/cmd/root_test.go
@@ -14,10 +14,13 @@
 
 package cmd
 
-import "testing"
+import (
+	"testing"
+	"context"
+)
 
 func TestHelp(t *testing.T) {
-	cmd, err := New([]string{"help", "cmd"})
+	cmd, err := New(context.Background(), []string{"help", "cmd"})
 	if err != nil || cmd == nil {
 		t.Error("help command failed unexpectedly")
 	}

--- a/cmd/cue/cmd/trim.go
+++ b/cmd/cue/cmd/trim.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -30,7 +31,7 @@ import (
 // - implement verification post-processing as extra safety
 
 // newTrimCmd creates a trim command
-func newTrimCmd(c *Command) *cobra.Command {
+func newTrimCmd(ctx context.Context, c *Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trim",
 		Short: "remove superfluous fields",
@@ -81,14 +82,14 @@ Examples:
 It is guaranteed that the resulting files give the same output as before the
 removal.
 `,
-		RunE: mkRunE(c, runTrim),
+		RunE: mkRunE(ctx, c, runTrim),
 	}
 
 	flagOut.Add(cmd)
 	return cmd
 }
 
-func runTrim(cmd *Command, args []string) error {
+func runTrim(ctx context.Context, cmd *Command, args []string) error {
 	// TODO: Do something more fine-grained. Optional fields are mostly not
 	// useful to consider as an optional field will almost never subsume
 	// another value. However, an optional field may subsume and therefore
@@ -103,7 +104,7 @@ func runTrim(cmd *Command, args []string) error {
 	if binst == nil {
 		return nil
 	}
-	instances := buildInstances(cmd, binst)
+	instances := buildInstances(ctx, cmd, binst)
 
 	// dst := flagName("o").String(cmd)
 	dst := flagOut.String(cmd)

--- a/cmd/cue/cmd/version.go
+++ b/cmd/cue/cmd/version.go
@@ -15,18 +15,19 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	goruntime "runtime"
 
 	"github.com/spf13/cobra"
 )
 
-func newVersionCmd(c *Command) *cobra.Command {
+func newVersionCmd(ctx context.Context, c *Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "print CUE version",
 		Long:  ``,
-		RunE:  mkRunE(c, runVersion),
+		RunE:  mkRunE(ctx, c, runVersion),
 	}
 	return cmd
 }
@@ -37,7 +38,7 @@ var (
 	version = "custom"
 )
 
-func runVersion(cmd *Command, args []string) error {
+func runVersion(ctx context.Context, cmd *Command, args []string) error {
 	w := cmd.OutOrStdout()
 	fmt.Fprintf(w, "cue version %v %s/%s\n",
 		version,

--- a/cmd/cue/main.go
+++ b/cmd/cue/main.go
@@ -15,11 +15,12 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"cuelang.org/go/cmd/cue/cmd"
 )
 
 func main() {
-	os.Exit(cmd.Main())
+	os.Exit(cmd.Main(context.Background()))
 }

--- a/internal/ctxio/ctxio.go
+++ b/internal/ctxio/ctxio.go
@@ -1,0 +1,62 @@
+// Copyright 2018 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctxio
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+type contextKey int
+
+const (
+	stdinKey contextKey = iota
+	stdoutKey
+	stderrKey
+)
+
+func WithStdin(ctx context.Context, stdin io.Reader) context.Context {
+	return context.WithValue(ctx, stdinKey, stdin)
+}
+
+func Stdin(ctx context.Context) io.Reader {
+	if stdin, ok := ctx.Value(stdinKey).(io.Reader); ok {
+		return stdin
+	}
+	return os.Stdin
+}
+
+func WithStdout(ctx context.Context, stdout io.Writer) context.Context {
+	return context.WithValue(ctx, stdoutKey, stdout)
+}
+
+func Stdout(ctx context.Context) io.Writer {
+	if stdout, ok := ctx.Value(stdoutKey).(io.Writer); ok {
+		return stdout
+	}
+	return os.Stdout
+}
+
+func WithStderr(ctx context.Context, stderr io.Writer) context.Context {
+	return context.WithValue(ctx, stderrKey, stderr)
+}
+
+func Stderr(ctx context.Context) io.Writer {
+	if stderr, ok := ctx.Value(stderrKey).(io.Writer); ok {
+		return stderr
+	}
+	return os.Stderr
+}


### PR DESCRIPTION
We're passing `cmd` around just for `stderr`. This PR decouples `cmd` and `stderr` making functions more logically correct and easier to test.

Also it removes `stdin`, `stdout`, `stderr` variables in the `cmd` package for cleanup. We can remove `inTest` in the same approach.

`context.Context` is quite extendable. We can add more functionality like trace, debug, verbose log without change function arguments in the future.