### PR TITLE
(WIP)cmd/cue/cmd: initial CUEFILE implementation with custom task and command

### DIFF
--- a/cmd/cue/cmd/common.go
+++ b/cmd/cue/cmd/common.go
@@ -180,3 +180,19 @@ func buildTools(cmd *Command, args []string) (*cue.Instance, error) {
 	inst := cue.Merge(insts...).Build(ti)
 	return inst, inst.Err
 }
+
+func buildCUEFILE() (*cue.Instance, error) {
+	ti := build.NewContext().NewInstance("", nil)
+
+	if _, err := os.Stat("./CUEFILE"); os.IsNotExist(err) {
+		inst := cue.Build([]*build.Instance{ti})[0]
+		return inst, inst.Err
+	}
+
+	err := ti.AddFile("./CUEFILE", nil)
+	if err != nil {
+		return nil, err
+	}
+	inst := cue.Build([]*build.Instance{ti})[0]
+	return inst, inst.Err
+}

--- a/internal/task/custom.go
+++ b/internal/task/custom.go
@@ -1,0 +1,85 @@
+package task
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"cuelang.org/go/cue"
+	"golang.org/x/xerrors"
+)
+
+type CustomTask struct {
+	bin          string
+	args         []string
+	doc          string
+	inputFormat  string
+	outputFormat string
+}
+
+func NewCustomTask(bin string, args []string, doc string) (*CustomTask, error) {
+	return &CustomTask{
+		bin:  bin,
+		args: args,
+		doc:  doc,
+	}, nil
+}
+
+func (t *CustomTask) Run(ctx *Context, v cue.Value) (results interface{}, err error) {
+	cmd := exec.CommandContext(ctx.Context, t.bin, t.args...)
+
+	get := func(name string) (f cue.Value, ok bool) {
+		c := v.Lookup(name)
+		// Although the schema defines a default versions, older implementations
+		// may not use it yet.
+		if !c.Exists() {
+			return
+		}
+		if err := c.Null(); err == nil {
+			return
+		}
+		return c, true
+	}
+	if input, ok := get("input"); ok {
+		stdin, err := json.Marshal(input)
+		if err != nil {
+			return nil, err
+		}
+		cmd.Stdin = bytes.NewBuffer(stdin)
+	}
+	_, captureOut := get("output")
+	if !captureOut {
+		cmd.Stdout = ctx.Stdout
+	}
+	_, captureErr := get("error")
+	if !captureErr {
+		cmd.Stderr = ctx.Stderr
+	}
+
+	update := map[string]interface{}{}
+	if captureOut {
+		var stdout []byte
+		stdout, err = cmd.Output()
+
+		if err == nil {
+			var output interface{}
+			err = json.Unmarshal(stdout, &output)
+			update["output"] = output
+		} else {
+			update["output"] = string(stdout)
+		}
+	} else {
+		err = cmd.Run()
+	}
+	update["success"] = err == nil
+	if err != nil {
+		if exit := (*exec.ExitError)(nil); xerrors.As(err, &exit) && captureErr {
+			update["error"] = string(exit.Stderr)
+		} else {
+			update = nil
+		}
+		err = fmt.Errorf("command %q failed: %v", t.doc, err)
+	}
+	return update, err
+}


### PR DESCRIPTION
This is a initial implementation for #215 .

Tested with following CUEFILE

```
import (
        "tool/cli"
)

user_task = task

task: env: {
        kind: "mydomain.com/env"
        cmd: ["/usr/bin/jq", "-n", "env"]
        schema: {
                kind: env.kind
                output: {...}
        }
}

command: demo: task: {
        env: user_task.env.schema & {
                output: {
                        USER: string
                }
        }
        display: cli.Print & {
                text: task.env.output.USER
        }
}
```

Run `cue demo` to show current linux user.

I wanted two demo two improvements in this PR:

 - Top level custom commands defined in CUEFILE
 - User defined task type in CUEFILE

I think the user defined task feature would unlock lots of potential. With a central task registry and proper tooling, we can wrap many existing tools into ready to use task types which could be used in custom commands defined by user.

This PR is for discussion about the CUEFILE approach. More work should be done to for a proper implementation.