### PR TITLE
cmd/cue-cmd: add cue-cmd to run custom commands in a single CUE file

### DIFF
--- a/cmd/cue-cmd/cmd/custom.go
+++ b/cmd/cue-cmd/cmd/custom.go
@@ -1,0 +1,394 @@
+// Copyright 2018 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+// This file contains code or initializing and running custom commands.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/internal"
+	itask "cuelang.org/go/internal/task"
+	_ "cuelang.org/go/pkg/tool/cli" // Register tasks
+	_ "cuelang.org/go/pkg/tool/exec"
+	_ "cuelang.org/go/pkg/tool/file"
+	_ "cuelang.org/go/pkg/tool/http"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	commandSection = "command"
+	taskSection    = "task"
+)
+
+func lookupString(obj cue.Value, key string) string {
+	str, err := obj.Lookup(key).String()
+	if err != nil {
+		return ""
+	}
+	return str
+}
+
+// Variables used for testing.
+var (
+	stdout io.Writer = os.Stdout
+	stderr io.Writer = os.Stderr
+)
+
+func addCustom(parent *cobra.Command, typ, name string, tools *cue.Instance) (*cobra.Command, error) {
+	if tools == nil {
+		return nil, errors.New("no commands defined")
+	}
+
+	// TODO: validate allowing incomplete.
+	o := tools.Lookup(typ, name)
+	if !o.Exists() {
+		return nil, o.Err()
+	}
+
+	usage := lookupString(o, "usage")
+	if usage == "" {
+		usage = name
+	}
+	sub := &cobra.Command{
+		Use:   usage,
+		Short: lookupString(o, "short"),
+		Long:  lookupString(o, "long"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return doTasks(typ, name, tools)
+		},
+	}
+	parent.AddCommand(sub)
+
+	// TODO: implement var/flag handling.
+	return sub, nil
+}
+
+type taskKey struct {
+	typ  string
+	name string
+	task string
+}
+
+func (k taskKey) keyForTask(taskName string) taskKey {
+	k.task = taskName
+	return k
+}
+
+func keyForReference(ref []string) (k taskKey) {
+	// command <command> task <task>
+	if len(ref) >= 4 && ref[2] == taskSection {
+		k.typ = ref[0]
+		k.name = ref[1]
+		k.task = ref[3]
+	}
+	return k
+}
+
+func (k taskKey) taskPath(task string) []string {
+	k.task = task
+	return []string{k.typ, k.name, taskSection, task}
+}
+
+func (k *taskKey) lookupTasks(root *cue.Instance) cue.Value {
+	return root.Lookup(k.typ, k.name, taskSection)
+}
+
+func doTasks(typ, command string, root *cue.Instance) error {
+	return executeTasks(typ, command, root)
+}
+
+func isTask(index map[taskKey]*task, root *cue.Instance, value cue.Value) (*task, bool) {
+	inst, path := value.Reference()
+	if path != nil && inst == root {
+		if task, ok := index[keyForReference(path)]; ok {
+			return task, true
+		}
+	}
+	return nil, false
+}
+
+// executeTasks runs user-defined tasks as part of a user-defined command.
+//
+// All tasks are started at once, but will block until tasks that they depend
+// on will continue.
+func executeTasks(typ, command string, root *cue.Instance) (err error) {
+	spec := taskKey{typ, command, ""}
+	tasks := spec.lookupTasks(root)
+
+	index := map[taskKey]*task{}
+
+	// Create task entries from spec.
+	queue := []*task{}
+	iter, err := tasks.Fields()
+	if err != nil {
+		return err
+	}
+	for i := 0; iter.Next(); i++ {
+		t, err := newTask(i, iter.Label(), iter.Value())
+		if err != nil {
+			return err
+		}
+		queue = append(queue, t)
+		index[spec.keyForTask(iter.Label())] = t
+	}
+
+	// Mark dependencies for unresolved nodes.
+	for _, t := range queue {
+		task := tasks.Lookup(t.name)
+
+		// Inject dependency in `$after` field
+		after := task.Lookup("$after")
+		if after.Err() == nil {
+			if dep, ok := isTask(index, root, after); ok {
+				t.dep[dep] = true
+			}
+			iter, err := after.List()
+			if err == nil {
+				for iter.Next() {
+					if dep, ok := isTask(index, root, iter.Value()); ok {
+						t.dep[dep] = true
+					}
+				}
+			}
+		}
+
+		// Inject reverse dependency in `$before` field
+		before := task.Lookup("$before")
+		if before.Err() == nil {
+			if dep, ok := isTask(index, root, before); ok {
+				dep.dep[t] = true
+			}
+			iter, err := before.List()
+			if err == nil {
+				for iter.Next() {
+					if dep, ok := isTask(index, root, iter.Value()); ok {
+						dep.dep[t] = true
+					}
+				}
+			}
+		}
+
+		task.Walk(func(v cue.Value) bool {
+			if v == task {
+				return true
+			}
+			if (after.Err() == nil && v.Equals(after)) || (before.Err() == nil && v.Equals(before)) {
+				return false
+			}
+			for _, r := range appendReferences(nil, root, v) {
+				if dep, ok := index[keyForReference(r)]; ok && t != dep {
+					v := root.Lookup(r...)
+					if v.IsIncomplete() && v.Kind() != cue.StructKind {
+						t.dep[dep] = true
+					}
+				}
+			}
+			return true
+		}, nil)
+	}
+
+	if isCyclic(queue) {
+		return errors.New("cyclic dependency in tasks") // TODO: better message.
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var m sync.Mutex
+
+	g, ctx := errgroup.WithContext(ctx)
+	for _, t := range queue {
+		t := t
+		g.Go(func() error {
+			for d := range t.dep {
+				<-d.done
+			}
+			defer close(t.done)
+			// TODO: This can be done concurrently once it is verified that this
+			// code does not look up new strings in the index and that the
+			// full configuration, as used by the tasks, is pre-evaluated.
+			m.Lock()
+			obj := tasks.Lookup(t.name)
+			// NOTE: ignore the linter warning for the following line:
+			// itask.Context is an internal type and we want to break if any
+			// fields are added.
+			update, err := t.Run(&itask.Context{ctx, stdout, stderr}, obj)
+			if err == nil && update != nil {
+				root, err = root.Fill(update, spec.taskPath(t.name)...)
+
+				if err == nil {
+					tasks = spec.lookupTasks(root)
+				}
+			}
+			m.Unlock()
+
+			if err != nil {
+				cancel()
+			}
+			return err
+		})
+	}
+	return g.Wait()
+}
+
+func appendReferences(a [][]string, root *cue.Instance, v cue.Value) [][]string {
+	inst, path := v.Reference()
+	if path != nil && inst == root {
+		a = append(a, path)
+		return a
+	}
+
+	switch op, args := v.Expr(); op {
+	case cue.NoOp:
+		v.Walk(nil, func(w cue.Value) {
+			if v != w {
+				a = appendReferences(a, root, w)
+			}
+		})
+	default:
+		for _, arg := range args {
+			a = appendReferences(a, root, arg)
+		}
+	}
+	return a
+}
+
+func isCyclic(tasks []*task) bool {
+	cc := cycleChecker{
+		visited: make([]bool, len(tasks)),
+		stack:   make([]bool, len(tasks)),
+	}
+	for _, t := range tasks {
+		if cc.isCyclic(t) {
+			return true
+		}
+	}
+	return false
+}
+
+type cycleChecker struct {
+	visited, stack []bool
+}
+
+func (cc *cycleChecker) isCyclic(t *task) bool {
+	i := t.index
+	if !cc.visited[i] {
+		cc.visited[i] = true
+		cc.stack[i] = true
+
+		for d := range t.dep {
+			if !cc.visited[d.index] && cc.isCyclic(d) {
+				return true
+			} else if cc.stack[d.index] {
+				return true
+			}
+		}
+	}
+	cc.stack[i] = false
+	return false
+}
+
+type task struct {
+	itask.Runner
+
+	index int
+	name  string
+	done  chan error
+	dep   map[*task]bool
+}
+
+var legacyKinds = map[string]string{
+	"exec":       "tool/exec.Run",
+	"http":       "tool/http.Do",
+	"print":      "tool/cli.Print",
+	"testserver": "cmd/cue/cmd.Test",
+}
+
+func newTask(index int, name string, v cue.Value) (*task, error) {
+	// Lookup kind for backwards compatibility.
+	// TODO: consider at some point whether kind can be removed.
+	kind, err := v.Lookup("kind").String()
+	if err != nil {
+		return nil, err
+	}
+	if k, ok := legacyKinds[kind]; ok {
+		kind = k
+	}
+	rf := itask.Lookup(kind)
+	if rf == nil {
+		return nil, fmt.Errorf("runner of kind %q not found", kind)
+	}
+
+	// Verify entry against template.
+	v = internal.UnifyBuiltin(v, kind).(cue.Value)
+	if err := v.Err(); err != nil {
+		return nil, err
+	}
+
+	runner, err := rf(v)
+	if err != nil {
+		return nil, err
+	}
+	return &task{
+		Runner: runner,
+		index:  index,
+		name:   name,
+		done:   make(chan error),
+		dep:    make(map[*task]bool),
+	}, nil
+}
+
+func init() {
+	itask.Register("cmd/cue/cmd.Test", newTestServerCmd)
+}
+
+var testOnce sync.Once
+
+func newTestServerCmd(v cue.Value) (itask.Runner, error) {
+	server := ""
+	testOnce.Do(func() {
+		s := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, req *http.Request) {
+				data, _ := ioutil.ReadAll(req.Body)
+				d := map[string]interface{}{
+					"data": string(data),
+					"when": "now",
+				}
+				enc := json.NewEncoder(w)
+				_ = enc.Encode(d)
+			}))
+		server = s.URL
+	})
+	return testServerCmd(server), nil
+}
+
+type testServerCmd string
+
+func (s testServerCmd) Run(ctx *itask.Context, v cue.Value) (x interface{}, err error) {
+	return map[string]interface{}{"url": string(s)}, nil
+}

--- a/cmd/cue-cmd/cmd/custom_test.go
+++ b/cmd/cue-cmd/cmd/custom_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestIsCyclic(t *testing.T) {
+	testCases := []struct {
+		// semi-colon-separated list of nodes with comma-separated list
+		// of dependencies.
+		tasks string
+		cycle bool
+	}{{
+		tasks: "",
+	}, {
+		tasks: "0",
+		cycle: true,
+	}, {
+		tasks: "1; 0",
+		cycle: true,
+	}, {
+		tasks: "1; 2; 3; 4;",
+	}, {
+		tasks: "1; 2; ; 4; 5; ",
+	}, {
+		tasks: "1; 2; 3; 4; 0",
+		cycle: true,
+	}}
+	for _, tc := range testCases {
+		t.Run(tc.tasks, func(t *testing.T) {
+			deps := strings.Split(tc.tasks, ";")
+			tasks := make([]*task, len(deps))
+			for i := range tasks {
+				tasks[i] = &task{index: i, dep: map[*task]bool{}}
+			}
+			for i, d := range deps {
+				if d == "" {
+					continue
+				}
+				for _, num := range strings.Split(d, ",") {
+					num = strings.TrimSpace(num)
+					if num == "" {
+						continue
+					}
+					x, err := strconv.Atoi(num)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Logf("%d -> %d", i, x)
+					tasks[i].dep[tasks[x]] = true
+				}
+			}
+			if got := isCyclic(tasks); got != tc.cycle {
+				t.Errorf("got %v; want %v", got, tc.cycle)
+			}
+		})
+	}
+}

--- a/cmd/cue-cmd/cmd/root.go
+++ b/cmd/cue-cmd/cmd/root.go
@@ -1,0 +1,117 @@
+// Copyright 2018 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/cue/token"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand initialize the root command with custom commands defined
+// in target CUE file
+func NewCommand() *cobra.Command {
+	var err error
+	root := &cobra.Command{
+		Use:   "cue-cmd",
+		Short: "cue-cmd execute custom command defined in target file",
+		Long: `cue-cmd execute custom command defined in target file.
+
+Commands are defined in CUE as follows:
+
+	command deploy: {
+		cmd:   "kubectl"
+		args:  [ "-f", "deploy" ]
+		in:    json.Encode($) // encode the emitted configuration.
+	}
+
+Add a shebang to a CUE file pointing to cue-cmd could make it executable.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		},
+	}
+	defer func(root *cobra.Command) {
+		if err != nil {
+			root.RunE = func(cmd *cobra.Command, args []string) error {
+				return err
+			}
+		}
+	}(root)
+	if len(os.Args) == 1 {
+		return root
+	}
+
+	p := os.Args[1]
+	if p == "-h" || p == "--help" {
+		return root
+	}
+
+	root.SetArgs(os.Args[2:])
+
+	var inst *cue.Instance
+	inst, err = buildFromFile(p)
+	if err != nil {
+		return root
+	}
+	commands := inst.Lookup("command")
+	if !commands.Exists() {
+		return root
+	}
+	i, err := commands.Fields()
+	if err != nil {
+		err = errors.Newf(token.NoPos, "could not create command definitions: %v", err)
+		return root
+	}
+	for i.Next() {
+		_, err = addCustom(root, "command", i.Label(), inst)
+		if err != nil {
+			return root
+		}
+	}
+	return root
+}
+
+func buildFromFile(filename string) (*cue.Instance, error) {
+	ti := build.NewContext(build.ParseFile(shebangParser)).NewInstance("", nil)
+
+	err := ti.AddFile(filename, nil)
+	if err != nil {
+		return nil, err
+	}
+	inst := cue.Build([]*build.Instance{ti})[0]
+	return inst, inst.Err
+}
+
+func shebangParser(filename string, src interface{}) (*ast.File, error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) > 2 && content[0] == '#' && content[1] == '!' {
+		if i := bytes.Index(content, []byte("\n")); i > 0 {
+			return parser.ParseFile(filename, content[i+1:])
+		}
+	}
+	return parser.ParseFile(filename, content)
+}

--- a/cmd/cue-cmd/main.go
+++ b/cmd/cue-cmd/main.go
@@ -1,0 +1,27 @@
+// Copyright 2018 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"cuelang.org/go/cmd/cue-cmd/cmd"
+)
+
+func main() {
+	if err := cmd.NewCommand().Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
As discussed in #215 and conversation on Slack, it might cause confusion to support two custom commands modes in CUE. So I added `cue-cmd` to support the use case that defining custom commands with a single file.

With the shebang support, we can make a `.cue` file executable. This is more generic that user doesn't have to define the commands in `CUEFILE`.

Example of a runnable CUE script:

```
#!/usr/bin/env cue-cmd
import (
        "tool/cli"
        "tool/exec"
)

command: demo: task: {
        env: exec.Run & {
                cmd: ["env"]
                stdout: string
        }
        display: cli.Print & {
                text: task.env.stdout
        }
}
```