### PR TITLE
cue/load: fix test breakage for Windows

### DIFF
--- a/cue/load/loader.go
+++ b/cue/load/loader.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"unicode"
 
+	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/encoding"
 	"cuelang.org/go/cue/errors"
@@ -51,7 +52,11 @@ func Instances(args []string, c *Config) []*build.Instance {
 	// TODO: this is work in progress. We aim to replace the original Go
 	// implementation, which is not ideal for CUE.
 	if len(args) > 0 {
-		arg := strings.Split(args[0], ":")[0]
+		arg := args[0]
+		p := strings.LastIndexByte(arg, ':')
+		if p >= 0 && ast.IsValidIdent(arg[p+1:]) {
+			arg = arg[:p]
+		}
 		if arg == "-" || encoding.MapExtension(filepath.Ext(arg)) != nil {
 			return []*build.Instance{l.cueFilesPackage(args)}
 		}


### PR DESCRIPTION
`:` can be used in file names in volume separators of paths. Only allow this is the value after `:` is a valid identifier.