### PR TITLE
Add help text to show yaml export option

### DIFF
--- a/cmd/cue/cmd/export.go
+++ b/cmd/cue/cmd/export.go
@@ -84,10 +84,13 @@ Formats
 The following formats are recognized:
 
 json    output as JSON
-		Outputs any CUE value.
+               Outputs any CUE value.
 
 text    output as raw text
-        The evaluated value must be of type string.
+                The evaluated value must be of type string.
+
+yaml    output as YAML
+                Outputs any CUE value.
 `,
 
 		RunE: mkRunE(c, runExport),


### PR DESCRIPTION
In #182, support for `cue export --out yaml` was added
but this wasn't reflected in the help text.