### PR TITLE
doc/tutorial/kubernetes: Fix wrong instruction in Kubernetes tutorial

### DIFF
--- a/doc/tutorial/kubernetes/README.md
+++ b/doc/tutorial/kubernetes/README.md
@@ -109,7 +109,7 @@ To accomplish this, we tell `cue` to put each object in the configuration
 tree at the path with the "kind" as first element and "name" as second.
 
 ```
-$ cue import ./... -p kube -l 'strings.ToCamel(kind)' -l metadata.name -f
+$ cue import ./... -p kube -l '"\(strings.ToCamel(kind))"' -l '"\(metadata.name)"' -f
 ```
 
 The added `-l` flag defines the labels for each object, based on values from
@@ -165,7 +165,7 @@ in the configuration files and then converts these recursively.
 <-- TODO: update import label format -->
 
 ```
-$ cue import ./... -p kube -l 'strings.ToCamel(kind)' -l metadata.name -f -R
+$ cue import ./... -p kube -l '"\(strings.ToCamel(kind))"' -l '"\(metadata.name)"' -f -R
 ```
 
 Now the file looks like:


### PR DESCRIPTION
While following the Kubernetes tutorial, I found that the following line did not work.

```
$ cue import ./... -p kube -l 'strings.ToCamel(kind)' -l metadata.name -f
```

It produces an error.

```
parser error in path "metadata.name": missing ',' in struct literal
```

It seems that string interpolation is missing. So I fixed these lines to use string interpolation.

(I am very new to CUE.)