### PR TITLE
Add "Attributes()" to the Go API

### DIFF
--- a/cue/types.go
+++ b/cue/types.go
@@ -2203,7 +2203,6 @@ func (v Value) Attributes() []Attribute {
 	// collect attribues
 	for _, a := range v.path.attrs.attr {
 		A := Attribute{internal.ParseAttrBody(token.NoPos, a.body())}
-		// attrs[a.key()] = A
 		A.SetName(a.key())
 		attrs = append(attrs, A)
 	}
@@ -2228,7 +2227,7 @@ func (a *Attribute) SetName(name string) {
 
 func (a *Attribute) Vals() map[string]string {
 	ret := map[string]string{}
-	for _, F := range a.attr.Fields{
+	for _, F := range a.attr.Fields {
 		ret[F.Key()] = F.Value()
 	}
 	return ret

--- a/cue/types.go
+++ b/cue/types.go
@@ -2190,9 +2190,48 @@ func (v Value) Attribute(key string) Attribute {
 	return Attribute{internal.NewNonExisting(key)}
 }
 
+// Attributes returne all attributes for the Value.
+func (v Value) Attributes() []Attribute {
+	// attrs := map[string]Attribute{}
+	attrs := []Attribute{}
+
+	// return empty
+	if v.path == nil || v.path.attrs == nil {
+		return attrs
+	}
+
+	// collect attribues
+	for _, a := range v.path.attrs.attr {
+		A := Attribute{internal.ParseAttrBody(token.NoPos, a.body())}
+		// attrs[a.key()] = A
+		A.SetName(a.key())
+		attrs = append(attrs, A)
+	}
+
+	return attrs
+}
+
 // An Attribute contains meta data about a field.
 type Attribute struct {
 	attr internal.Attr
+}
+
+// Err returns the error associated with this Attribute or nil if this
+// attribute is valid.
+func (a *Attribute) Name() string {
+	return a.attr.Name
+}
+
+func (a *Attribute) SetName(name string) {
+	a.attr.SetName(name)
+}
+
+func (a *Attribute) Vals() map[string]string {
+	ret := map[string]string{}
+	for _, F := range a.attr.Fields{
+		ret[F.Key()] = F.Value()
+	}
+	return ret
 }
 
 // Err returns the error associated with this Attribute or nil if this

--- a/cue/types.go
+++ b/cue/types.go
@@ -2203,7 +2203,6 @@ func (v Value) Attributes() []Attribute {
 	// collect attribues
 	for _, a := range v.path.attrs.attr {
 		A := Attribute{internal.ParseAttrBody(token.NoPos, a.body())}
-		// attrs[a.key()] = A
 		A.SetName(a.key())
 		attrs = append(attrs, A)
 	}
@@ -2228,11 +2227,7 @@ func (a *Attribute) SetName(name string) {
 
 func (a *Attribute) Vals() map[string]string {
 	ret := map[string]string{}
-<<<<<<< HEAD
 	for _, F := range a.attr.Fields {
-=======
-	for _, F := range a.attr.Fields{
->>>>>>> another variation on exposing a function to get all attrs for a field
 		ret[F.Key()] = F.Value()
 	}
 	return ret

--- a/cue/types.go
+++ b/cue/types.go
@@ -2203,6 +2203,7 @@ func (v Value) Attributes() []Attribute {
 	// collect attribues
 	for _, a := range v.path.attrs.attr {
 		A := Attribute{internal.ParseAttrBody(token.NoPos, a.body())}
+		// attrs[a.key()] = A
 		A.SetName(a.key())
 		attrs = append(attrs, A)
 	}
@@ -2227,7 +2228,11 @@ func (a *Attribute) SetName(name string) {
 
 func (a *Attribute) Vals() map[string]string {
 	ret := map[string]string{}
+<<<<<<< HEAD
 	for _, F := range a.attr.Fields {
+=======
+	for _, F := range a.attr.Fields{
+>>>>>>> another variation on exposing a function to get all attrs for a field
 		ret[F.Key()] = F.Value()
 	}
 	return ret

--- a/internal/attrs.go
+++ b/internal/attrs.go
@@ -43,8 +43,16 @@ type KeyValue struct {
 }
 
 func (kv *KeyValue) Text() string { return kv.data }
-func (kv *KeyValue) Key() string  { return kv.data[:kv.equal] }
+func (kv *KeyValue) Key() string  {
+	if kv.equal == 0 {
+		return kv.data
+	}
+	return kv.data[:kv.equal]
+}
 func (kv *KeyValue) Value() string {
+	if kv.equal == 0 {
+		return ""
+	}
 	return strings.TrimSpace(kv.data[kv.equal+1:])
 }
 

--- a/internal/attrs.go
+++ b/internal/attrs.go
@@ -26,7 +26,8 @@ import (
 
 // Attr holds positional information for a single Attr.
 type Attr struct {
-	Fields []keyValue
+	Name   string
+	Fields []KeyValue
 	Err    error
 }
 
@@ -36,14 +37,14 @@ func NewNonExisting(key string) Attr {
 	return Attr{Err: errors.Newf(token.NoPos, msgNotExist, key)}
 }
 
-type keyValue struct {
+type KeyValue struct {
 	data  string
 	equal int // index of equal sign or 0 if non-existing
 }
 
-func (kv *keyValue) Text() string { return kv.data }
-func (kv *keyValue) Key() string  { return kv.data[:kv.equal] }
-func (kv *keyValue) Value() string {
+func (kv *KeyValue) Text() string { return kv.data }
+func (kv *KeyValue) Key() string  { return kv.data[:kv.equal] }
+func (kv *KeyValue) Value() string {
 	return strings.TrimSpace(kv.data[kv.equal+1:])
 }
 
@@ -55,6 +56,10 @@ func (a *Attr) hasPos(p int) error {
 		return fmt.Errorf("field does not exist")
 	}
 	return nil
+}
+
+func (a *Attr) SetName(name string) {
+	a.Name = name
 }
 
 // String reports the possibly empty string value at the given position or
@@ -129,7 +134,7 @@ func ParseAttrBody(pos token.Pos, s string) (a Attr) {
 
 func scanAttributeElem(pos token.Pos, s string, a *Attr) (n int, err errors.Error) {
 	// try CUE string
-	kv := keyValue{}
+	kv := KeyValue{}
 	if n, kv.data, err = scanAttributeString(pos, s); n == 0 {
 		// try key-value pair
 		p := strings.IndexAny(s, ",=") // ) is assumed to be stripped.

--- a/internal/attrs.go
+++ b/internal/attrs.go
@@ -53,8 +53,6 @@ func (kv *KeyValue) Value() string {
 	if kv.equal == 0 {
 		return ""
 	}
-	return strings.TrimSpace(kv.data[kv.equal+1:])
-}
 
 func (a *Attr) hasPos(p int) error {
 	if a.Err != nil {

--- a/internal/attrs.go
+++ b/internal/attrs.go
@@ -53,6 +53,8 @@ func (kv *KeyValue) Value() string {
 	if kv.equal == 0 {
 		return ""
 	}
+	return strings.TrimSpace(kv.data[kv.equal+1:])
+}
 
 func (a *Attr) hasPos(p int) error {
 	if a.Err != nil {


### PR DESCRIPTION
Another variation on exposing a function to get all attrs for a field, as this is a common use case on Go when using the API.

this one:
- Attributes() returns a slice of Attribute
- Exposes some new helper funcs on Attribute to get at the private fields and such

let me know what you think