### PR TITLE
pkg/strings: add SliceRunes

### DIFF
--- a/cue/builtin_test.go
+++ b/cue/builtin_test.go
@@ -395,6 +395,9 @@ func TestBuiltins(t *testing.T) {
 		test("strings", `strings.ByteSlice("Hello", 2, 5)`),
 		`'llo'`,
 	}, {
+		test("strings", `strings.SliceRunes("✓ Hello", 0, 3)`),
+		`"✓ H"`,
+	}, {
 		test("strings", `strings.Runes("Café")`),
 		strings.Replace(fmt.Sprint([]rune{'C', 'a', 'f', 'é'}), " ", ",", -1),
 	}, {

--- a/cue/builtins.go
+++ b/cue/builtins.go
@@ -2927,6 +2927,22 @@ var builtinPackages = map[string]*builtinPkg{
 				}
 			},
 		}, {
+			Name:   "SliceRunes",
+			Params: []kind{stringKind, intKind, intKind},
+			Result: stringKind,
+			Func: func(c *callCtxt) {
+				b, start, end := c.string(0), c.int(1), c.int(2)
+				if c.do() {
+					c.ret, c.err = func() (interface{}, error) {
+						runes := []rune(b)
+						if start < 0 || start > end || end > len(runes) {
+							return nil, fmt.Errorf("index out of range")
+						}
+						return string(runes[start:end]), nil
+					}()
+				}
+			},
+		}, {
 			Name:   "ToTitle",
 			Params: []kind{stringKind},
 			Result: stringKind,

--- a/pkg/strings/manual.go
+++ b/pkg/strings/manual.go
@@ -108,3 +108,13 @@ func ToCamel(s string) string {
 		},
 		s)
 }
+
+// SliceRunes returns a string of the underlying string data from the start index
+// up to but not including the end index.
+func SliceRunes(s string, start, end int) (string, error) {
+	runes := Runes(s)
+	if start < 0 || start > end || end > len(runes) {
+		return "", fmt.Errorf("index out of range")
+	}
+	return string(runes[start:end]), nil
+}


### PR DESCRIPTION
There was some discussions on slack about this and turns out there is no real solution to slice strings easily in cue.

Added a builtin which works internally on runes to work properly on strings with unicode chars.

Not sure about the name of the builtin.