### PR TITLE
cue: add function for Value.Attributes()

### DIFF
--- a/cue/types.go
+++ b/cue/types.go
@@ -2151,9 +2151,46 @@ func (v Value) Attribute(key string) Attribute {
 	return Attribute{internal.NewNonExisting(key)}
 }
 
+// Attributes returne all attributes for the Value.
+func (v Value) Attributes() []Attribute {
+	// attrs := map[string]Attribute{}
+	attrs := []Attribute{}
+
+	// return empty
+	if v.v == nil {
+		return attrs
+	}
+
+	// collect attribues
+	for _, a := range export.ExtractFieldAttrs(v.v.Conjuncts) {
+		key, body := a.Split()
+		A := Attribute{internal.ParseAttrBody(token.NoPos, body)}
+		A.SetName(key)
+		attrs = append(attrs, A)
+	}
+
+	return attrs
+}
+
 // An Attribute contains meta data about a field.
 type Attribute struct {
 	attr internal.Attr
+}
+
+func (a *Attribute) Name() string {
+	return a.attr.Name
+}
+
+func (a *Attribute) SetName(name string) {
+	a.attr.SetName(name)
+}
+
+func (a *Attribute) Vals() map[string]string {
+	ret := map[string]string{}
+	for _, F := range a.attr.Fields {
+		ret[F.Key()] = F.Value()
+	}
+	return ret
 }
 
 // Err returns the error associated with this Attribute or nil if this

--- a/cue/types.go
+++ b/cue/types.go
@@ -2151,7 +2151,7 @@ func (v Value) Attribute(key string) Attribute {
 	return Attribute{internal.NewNonExisting(key)}
 }
 
-// Attributes reports all field attributes for a Value.
+// Attributes reports all attributes for the Value.
 func (v Value) Attributes() []Attribute {
 	attrs := []Attribute{}
 
@@ -2164,7 +2164,7 @@ func (v Value) Attributes() []Attribute {
 	for _, a := range export.ExtractFieldAttrs(v.v.Conjuncts) {
 		key, body := a.Split()
 		A := Attribute{internal.ParseAttrBody(token.NoPos, body)}
-		A.attr.Name = key
+		A.SetName(key)
 		attrs = append(attrs, A)
 	}
 
@@ -2179,6 +2179,15 @@ type Attribute struct {
 // Name returns the '@name(...)' for the Attribute.
 func (a *Attribute) Name() string {
 	return a.attr.Name
+}
+
+// Map returns all key/value pairs for the attribute as a map
+func (a *Attribute) Map() map[string]string {
+	ret := map[string]string{}
+	for _, F := range a.attr.Fields {
+		ret[F.Key()] = F.Value()
+	}
+	return ret
 }
 
 // Err returns the error associated with this Attribute or nil if this

--- a/cue/types.go
+++ b/cue/types.go
@@ -2151,7 +2151,7 @@ func (v Value) Attribute(key string) Attribute {
 	return Attribute{internal.NewNonExisting(key)}
 }
 
-// Attributes reports all attributes for the Value.
+// Attributes reports all field attributes for the Value.
 func (v Value) Attributes() []Attribute {
 	attrs := []Attribute{}
 

--- a/cue/types.go
+++ b/cue/types.go
@@ -2151,12 +2151,11 @@ func (v Value) Attribute(key string) Attribute {
 	return Attribute{internal.NewNonExisting(key)}
 }
 
-// Attributes returne all attributes for the Value.
+// Attributes reports all field attributes for a Value.
 func (v Value) Attributes() []Attribute {
-	// attrs := map[string]Attribute{}
 	attrs := []Attribute{}
 
-	// return empty
+	// return empty when vertex is nil
 	if v.v == nil {
 		return attrs
 	}
@@ -2165,7 +2164,7 @@ func (v Value) Attributes() []Attribute {
 	for _, a := range export.ExtractFieldAttrs(v.v.Conjuncts) {
 		key, body := a.Split()
 		A := Attribute{internal.ParseAttrBody(token.NoPos, body)}
-		A.SetName(key)
+		A.attr.Name = key
 		attrs = append(attrs, A)
 	}
 
@@ -2177,20 +2176,9 @@ type Attribute struct {
 	attr internal.Attr
 }
 
+// Name returns the '@name(...)' for the Attribute.
 func (a *Attribute) Name() string {
 	return a.attr.Name
-}
-
-func (a *Attribute) SetName(name string) {
-	a.attr.SetName(name)
-}
-
-func (a *Attribute) Vals() map[string]string {
-	ret := map[string]string{}
-	for _, F := range a.attr.Fields {
-		ret[F.Key()] = F.Value()
-	}
-	return ret
 }
 
 // Err returns the error associated with this Attribute or nil if this

--- a/cue/types.go
+++ b/cue/types.go
@@ -2164,7 +2164,7 @@ func (v Value) Attributes() []Attribute {
 	for _, a := range export.ExtractFieldAttrs(v.v.Conjuncts) {
 		key, body := a.Split()
 		A := Attribute{internal.ParseAttrBody(token.NoPos, body)}
-		A.SetName(key)
+		A.attr.Name = key
 		attrs = append(attrs, A)
 	}
 

--- a/internal/attrs.go
+++ b/internal/attrs.go
@@ -26,6 +26,7 @@ import (
 
 // Attr holds positional information for a single Attr.
 type Attr struct {
+	Name   string
 	Fields []keyValue
 	Err    error
 }
@@ -42,9 +43,21 @@ type keyValue struct {
 }
 
 func (kv *keyValue) Text() string { return kv.data }
-func (kv *keyValue) Key() string  { return kv.data[:kv.equal] }
+func (kv *keyValue) Key() string  {
+	if kv.equal == 0 {
+		return kv.data
+	}
+	return kv.data[:kv.equal]
+}
 func (kv *keyValue) Value() string {
+	if kv.equal == 0 {
+		return ""
+	}
 	return strings.TrimSpace(kv.data[kv.equal+1:])
+}
+
+func (a *Attr) SetName(name string) {
+	a.Name = name
 }
 
 func (a *Attr) hasPos(p int) error {

--- a/internal/attrs.go
+++ b/internal/attrs.go
@@ -56,10 +56,6 @@ func (kv *keyValue) Value() string {
 	return strings.TrimSpace(kv.data[kv.equal+1:])
 }
 
-func (a *Attr) SetName(name string) {
-	a.Name = name
-}
-
 func (a *Attr) hasPos(p int) error {
 	if a.Err != nil {
 		return a.Err


### PR DESCRIPTION
This enables a user of the Go API to get all attributes so they can inspect them, rather than only being able to ask if a particular attribute exists on a value. Really useful for tools leveraging CUE!

I recall @mpvl might have wanted the return to be a Value or List rather than the slice?