### PR TITLE
Add strings.NumRunes function

### DIFF
--- a/pkg/strings/manual.go
+++ b/pkg/strings/manual.go
@@ -53,10 +53,10 @@ func Runes(s string) []rune {
 	return []rune(s)
 }
 
-// ExactRunes reports whether the number of runes (Unicode codepoints) in a
-// string is equal to the provided number. ExactRunes can be used as a field
+// NumRunes reports whether the number of runes (Unicode codepoints) in a
+// string is equal to the provided number. NumRunes can be used as a field
 // constraint to accept all strings for which this property holds.
-func ExactRunes(s string, num int) bool {
+func RunRunes(s string, num int) bool {
 	return len([]rune(s)) == num
 }
 

--- a/pkg/strings/manual.go
+++ b/pkg/strings/manual.go
@@ -53,9 +53,16 @@ func Runes(s string) []rune {
 	return []rune(s)
 }
 
+// ExactRunes reports whether the number of runes (Unicode codepoints) in a
+// string is equal to the provided number. ExactRunes can be used as a field
+// constraint to accept all strings for which this property holds.
+func ExactRunes(s string, num int) bool {
+	return len([]rune(s)) == num
+}
+
 // MinRunes reports whether the number of runes (Unicode codepoints) in a string
 // is at least a certain minimum. MinRunes can be used a a field constraint to
-// except all strings for which this property holds.
+// accept all strings for which this property holds.
 func MinRunes(s string, min int) bool {
 	// TODO: CUE strings cannot be invalid UTF-8. In case this changes, we need
 	// to use the following conversion to count properly:
@@ -65,7 +72,7 @@ func MinRunes(s string, min int) bool {
 
 // MaxRunes reports whether the number of runes (Unicode codepoints) in a string
 // exceeds a certain maximum. MaxRunes can be used a a field constraint to
-// except all strings for which this property holds
+// accept all strings for which this property holds
 func MaxRunes(s string, max int) bool {
 	// See comment in MinRunes implementation.
 	return len([]rune(s)) <= max

--- a/pkg/strings/pkg.go
+++ b/pkg/strings/pkg.go
@@ -38,6 +38,16 @@ var pkg = &internal.Package{
 			}
 		},
 	}, {
+		Name:   "ExactRunes",
+		Params: []adt.Kind{adt.StringKind},
+		Result: adt.BoolKind,
+		Func: func(c *internal.CallCtxt) {
+			s, num := c.String(0), c.Int(1)
+			if c.Do() {
+				c.Ret = ExactRunes(s, num)
+			}
+		},
+	}, {
 		Name:   "Runes",
 		Params: []adt.Kind{adt.StringKind},
 		Result: adt.ListKind,

--- a/pkg/strings/pkg.go
+++ b/pkg/strings/pkg.go
@@ -38,13 +38,13 @@ var pkg = &internal.Package{
 			}
 		},
 	}, {
-		Name:   "ExactRunes",
+		Name:   "NumRunes",
 		Params: []adt.Kind{adt.StringKind, adt.IntKind},
 		Result: adt.BoolKind,
 		Func: func(c *internal.CallCtxt) {
 			s, num := c.String(0), c.Int(1)
 			if c.Do() {
-				c.Ret = ExactRunes(s, num)
+				c.Ret = NumRunes(s, num)
 			}
 		},
 	}, {

--- a/pkg/strings/pkg.go
+++ b/pkg/strings/pkg.go
@@ -39,7 +39,7 @@ var pkg = &internal.Package{
 		},
 	}, {
 		Name:   "ExactRunes",
-		Params: []adt.Kind{adt.StringKind},
+		Params: []adt.Kind{adt.StringKind, adt.IntKind},
 		Result: adt.BoolKind,
 		Func: func(c *internal.CallCtxt) {
 			s, num := c.String(0), c.Int(1)

--- a/pkg/strings/testdata/gen.txtar
+++ b/pkg/strings/testdata/gen.txtar
@@ -20,9 +20,9 @@ t14: strings.MinRunes(3) & "hello"
 t15: strings.MaxRunes(10) & "hello"
 t16: strings.MaxRunes(3) & "hello"
 t17: strings.MinRunes(10) & "hello"
-t18: strings.ExactRunes(5) & "hello"
-t19: strings.ExactRunes(5) & "hello world"
-t20: strings.ExactRunes(0) & ""
+t18: strings.NumRunes(5) & "hello"
+t19: strings.NumRunes(5) & "hello world"
+t20: strings.NumRunes(0) & ""
 -- out/strings --
 Errors:
 0: error in call to strings.Join: element 0 of list argument 0: cannot use value 1 (type int) as string
@@ -34,7 +34,7 @@ t16: invalid value "hello" (does not satisfy strings.MaxRunes(3)):
     ./in.cue:18:6
 t17: invalid value "hello" (does not satisfy strings.MinRunes(10)):
     ./in.cue:19:6
-t19: invalid value "hello world" (does not satisfy strings.ExactRunes(5)):
+t19: invalid value "hello world" (does not satisfy strings.NumRunes(5)):
     ./in.cue:21:6
 
 Result:
@@ -78,7 +78,7 @@ Result:
   }
   t18: (string){ "hello" }
   t19: (_|_){
-    // [eval] t19: invalid value "hello world" (does not satisfy strings.ExactRunes(5)):
+    // [eval] t19: invalid value "hello world" (does not satisfy strings.NumRunes(5)):
     //     ./in.cue:21:6
   }
   t20: (string){ "" }

--- a/pkg/strings/testdata/gen.txtar
+++ b/pkg/strings/testdata/gen.txtar
@@ -20,6 +20,9 @@ t14: strings.MinRunes(3) & "hello"
 t15: strings.MaxRunes(10) & "hello"
 t16: strings.MaxRunes(3) & "hello"
 t17: strings.MinRunes(10) & "hello"
+t18: strings.ExactRunes(5) & "hello"
+t19: strings.ExactRunes(5) & "hello world"
+t20: strings.ExactRunes(0) & ""
 -- out/strings --
 Errors:
 0: error in call to strings.Join: element 0 of list argument 0: cannot use value 1 (type int) as string
@@ -31,6 +34,8 @@ t16: invalid value "hello" (does not satisfy strings.MaxRunes(3)):
     ./in.cue:18:6
 t17: invalid value "hello" (does not satisfy strings.MinRunes(10)):
     ./in.cue:19:6
+t19: invalid value "hello world" (does not satisfy strings.ExactRunes(5)):
+    ./in.cue:21:6
 
 Result:
 (_|_){
@@ -71,4 +76,10 @@ Result:
     // [eval] t17: invalid value "hello" (does not satisfy strings.MinRunes(10)):
     //     ./in.cue:19:6
   }
+  t18: (string){ "hello" }
+  t19: (_|_){
+    // [eval] t19: invalid value "hello world" (does not satisfy strings.ExactRunes(5)):
+    //     ./in.cue:21:6
+  }
+  t20: (string){ "" }
 }


### PR DESCRIPTION
This PR provides an `ExactRunes` function that prevents you from needing to do things like this:

```
username: strings.MaxRunes(8) & strings.MinRunes(8)
```