### PR TITLE
encoding/gocode: use FieldByName in generated code

### DIFF
--- a/encoding/gocode/templates.go
+++ b/encoding/gocode/templates.go
@@ -81,7 +81,7 @@ var {{.prefix}}Codec, {{.prefix}}Instance = func() (*gocodec.Codec, *cue.Instanc
 // {{.prefix}}Make is called in the init phase to initialize CUE values for
 // validation functions.
 func {{.prefix}}Make(name string, x interface{}) cue.Value {
-	f, err := {{.prefix}}Instance.LookupField(name)
+	f, err := {{.prefix}}Instance.Value().FieldByName(name, true)
 	if err != nil {
 		panic(fmt.Errorf("could not find type %q in instance", name))
 	}

--- a/encoding/gocode/testdata/pkg1/cue_gen.go
+++ b/encoding/gocode/testdata/pkg1/cue_gen.go
@@ -66,7 +66,7 @@ var cuegenCodec, cuegenInstance = func() (*gocodec.Codec, *cue.Instance) {
 // cuegenMake is called in the init phase to initialize CUE values for
 // validation functions.
 func cuegenMake(name string, x interface{}) cue.Value {
-	f, err := cuegenInstance.LookupField(name)
+	f, err := cuegenInstance.Value().FieldByName(name, true)
 	if err != nil {
 		panic(fmt.Errorf("could not find type %q in instance", name))
 	}

--- a/encoding/gocode/testdata/pkg2/cue_gen.go
+++ b/encoding/gocode/testdata/pkg2/cue_gen.go
@@ -40,7 +40,7 @@ var cuegenCodec, cuegenInstance = func() (*gocodec.Codec, *cue.Instance) {
 // cuegenMake is called in the init phase to initialize CUE values for
 // validation functions.
 func cuegenMake(name string, x interface{}) cue.Value {
-	f, err := cuegenInstance.LookupField(name)
+	f, err := cuegenInstance.Value().FieldByName(name, true)
 	if err != nil {
 		panic(fmt.Errorf("could not find type %q in instance", name))
 	}


### PR DESCRIPTION
The code generated by `encoding/gocode` is triggering a deprecation warning:

```
cuegenInstance.LookupField is deprecated: this API does not work with new-style definitions. Use FieldByName defined on inst.Value().  (SA1019)
```

This change uses the advice from the deprecation and makes the target code use `.Value().FieldByName(...)` instead of `LookupField` on the instance.