### PR TITLE
doc/../43_schema.txt: remove unnecessary word

### DIFF
--- a/doc/tutorial/basics/0_intro/43_schema.txt
+++ b/doc/tutorial/basics/0_intro/43_schema.txt
@@ -8,7 +8,7 @@ description = ""
 -- text.md --
 In CUE, schemas are typically written as Definitions.
 A definition is a field which identifier starts with
-a `#` or `_#`.
+`#` or `_#`.
 This tells CUE that they are to be used for validation and should
 not be output as data; it is okay for them to remain unspecified.
 


### PR DESCRIPTION
For consistency with https://github.com/cuelang/cue/blob/master/doc/tutorial/basics/2_types/55_defs.txt, this removes an unnecessary "a". Without the extra word, it also arguably _reads_ better, since readers aren't necessarily "pronouncing" hashtag/pound-sign in their minds as they read the text.