### PR TITLE
Invert order in struct fields docs

### DIFF
--- a/doc/tutorial/basics/0_intro/50_order.txt
+++ b/doc/tutorial/basics/0_intro/50_order.txt
@@ -15,10 +15,10 @@ makes advanced tooling and automation possible.
 
 -- order.cue --
 a: {x: 1, y: int}
-a: {x: int, y: 2}
+a: {y: 2, x: int}
 
 b: {x: int, y: 2}
-b: {x: 1, y: int}
+b: {y: int, x: 1}
 
 -- expect-stdout-cue --
 a: {


### PR DESCRIPTION
This example was a bit hard to grasp until I actually inverted the order of the fields in the structs and checked that indeed the outcome was still the same. Proposing a change here to see if this change actually reflects the intent