### PR TITLE
doc/tutorial: address cuelang/cuelang.org#126

### DIFF
--- a/doc/tutorial/basics/2_types/05_types.txt
+++ b/doc/tutorial/basics/2_types/05_types.txt
@@ -43,10 +43,10 @@ point: {
 }
 
 xaxis: point
-xaxis: x: 0
+xaxis: y: 0
 
 yaxis: point
-yaxis: y: 0
+yaxis: x: 0
 
 origin: xaxis & yaxis
 
@@ -56,12 +56,12 @@ point: {
     y: number
 }
 xaxis: {
-    x: 0
-    y: number
-}
-yaxis: {
     x: number
     y: 0
+}
+yaxis: {
+    x: 0
+    y: number
 }
 origin: {
     x: 0


### PR DESCRIPTION
@j-bai raised https://github.com/cuelang/cuelang.org/issues/126, pointing out that the roles of `xaxis` and `yaxis` are backwards. This addresses the issue.