### PR TITLE
Ensure we read from overlay when calling readDir

### DIFF
--- a/cue/load/fs.go
+++ b/cue/load/fs.go
@@ -175,6 +175,9 @@ func (fs *fileSystem) readDir(path string) ([]os.FileInfo, errors.Error) {
 			items[i] = of
 			i++
 		}
+		sort.Slice(items, func(i, j int) bool {
+			return items[i].Name() < items[j].Name()
+		})
 		return items, nil
 	}
 

--- a/cue/load/fs.go
+++ b/cue/load/fs.go
@@ -167,6 +167,17 @@ func hasSubdir(root, dir string) (rel string, ok bool) {
 
 func (fs *fileSystem) readDir(path string) ([]os.FileInfo, errors.Error) {
 	path = fs.makeAbs(path)
+
+	if fi := fs.getDir(path, false); fi != nil {
+		items := make([]os.FileInfo, len(fi))
+		i := 0
+		for _, of := range fi {
+			items[i] = of
+			i++
+		}
+		return items, nil
+	}
+
 	m := fs.getDir(path, false)
 	items, err := ioutil.ReadDir(path)
 	if err != nil {

--- a/cue/load/import.go
+++ b/cue/load/import.go
@@ -142,6 +142,10 @@ func (l *loader) importPkg(pos token.Pos, p *build.Instance) []*build.Instance {
 
 	found := false
 	for _, d := range dirs {
+		if d[1] == "/" {
+			found = true
+			break
+		}
 		info, err := ctxt.stat(d[1])
 		if err == nil && info.IsDir() {
 			found = true

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/cockroachdb/apd/v2"
@@ -414,6 +415,9 @@ func IsEllipsis(x ast.Decl) bool {
 
 // GenPath reports the directory in which to store generated files.
 func GenPath(root string) string {
+	if runtime.GOOS == "js" {
+		return filepath.Join(root, "cue.mod", "gen")
+	}
 	info, err := os.Stat(filepath.Join(root, "cue.mod"))
 	if os.IsNotExist(err) || !info.IsDir() {
 		// Try legacy pkgDir mode


### PR DESCRIPTION
`fileSystem.readDir` always reads from the actual filesystem, even if
there is an overaly directory present.  Read from the overlay directory
in these circumstances;  we shouldn't be hitting the disk.

Also, if the root path is "/" we can skip loading and return true.  This
allows fully in-memory packages as per
https://github.com/cuelang/cue/issues/607.

This helps with fix certain aspects in #607, but does not refactor `fileSystem`
to use any of the newer interfaces that we could.