### PR TITLE
pkg/native: added utils to make custom pkg easier

### DIFF
--- a/pkg/native/package.go
+++ b/pkg/native/package.go
@@ -1,0 +1,260 @@
+package native
+
+import (
+	encodingjson "encoding/json"
+	"fmt"
+	"go/ast"
+	"reflect"
+	"strconv"
+
+	"cuelang.org/go/cue"
+	cueast "cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/literal"
+	"cuelang.org/go/encoding/json"
+	"cuelang.org/go/internal/core/adt"
+	"cuelang.org/go/pkg/internal"
+)
+
+type Package interface {
+	// ImportPath name of Package
+	//
+	// Exported Methods
+	//
+	// Func:
+	// 		func () SomeMethod(arg ...interface{}) (...interface{}, error)
+	// Const:
+	//      func () Const() interface{}
+	//
+	// Func params will convert from cue.Value,
+	// struct values need json tag for unmarshalling
+	ImportPath() string
+}
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+func newInternalPackage(pkg Package) *internal.Package {
+	p := &internal.Package{}
+
+	importPath := pkg.ImportPath()
+
+	rv := reflect.ValueOf(pkg)
+	t := rv.Type()
+
+	for i := 0; i < rv.NumMethod(); i++ {
+		m := rv.Method(i)
+		mt := t.Method(i)
+		name := mt.Name
+
+		if !ast.IsExported(name) || name == "ImportPath" {
+			continue
+		}
+
+		fnT := m.Type()
+
+		switch fnT.NumOut() {
+		case 2:
+			if fnT.NumIn() > 0 {
+				if err := fnT.Out(1); err.Kind() == reflect.Interface && err.AssignableTo(errorType) {
+
+					params := make([]internal.Param, fnT.NumIn())
+					inputs := make([]reflect.Type, len(params))
+
+					for i := range params {
+						in := fnT.In(i)
+
+						params[i] = internal.Param{Kind: adtKindFromReflectType(in)}
+						inputs[i] = in
+					}
+
+					resultKind := adtKindFromReflectType(fnT.Out(0))
+
+					builtin := &internal.Builtin{
+						Name:   name,
+						Params: params,
+						Result: resultKind,
+						Func: func(c *internal.CallCtxt) {
+							values := make([]reflect.Value, len(params))
+
+							for i := range values {
+								rv := reflect.New(inputs[i]).Elem()
+
+								cueValue := c.Value(i)
+
+								if err := setValue(rv, cueValue); err != nil {
+									c.Err = errors.Wrapf(err, c.Pos(), "parameter %d of %s.%s should be %s, but got %s", i, importPath, name, params[i], cueValue.Kind())
+									return
+								}
+
+								values[i] = rv
+							}
+
+							if c.Do() {
+								outputs := m.Call(values)
+
+								if resultKind == adt.ScalarKinds {
+									c.Ret, c.Err = outputs[0].Interface(), outputs[1].Interface()
+								} else {
+									c.Err = outputs[1].Interface()
+									if c.Err == nil {
+										ret, err := cueAstExprFromGoValues(outputs[0].Interface())
+										if err != nil {
+											c.Err = err
+										} else {
+											c.Ret = ret
+										}
+									}
+								}
+							}
+						},
+					}
+
+					p.Native = append(p.Native, builtin)
+				}
+			}
+		case 1:
+			if fnT.NumIn() == 0 {
+				outputs := m.Call(nil)[0]
+
+				p.Native = append(p.Native, &internal.Builtin{
+					Name:  name,
+					Const: cueLitFromGoValue(outputs.Interface()),
+				})
+			}
+		}
+	}
+
+	return p
+}
+
+func cueLitFromGoValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return literal.String.Quote(v)
+	case []byte:
+		return literal.Bytes.Quote(string(v))
+	case int:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case fmt.Stringer:
+		return v.String()
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		panic(fmt.Errorf("unsupported value %#v", v))
+	}
+}
+
+func cueAstExprFromGoValues(v interface{}) (cueast.Expr, error) {
+	data, err := encodingjson.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return json.Extract("v", data)
+}
+
+func setValue(rv reflect.Value, v cue.Value) error {
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			rv.Set(reflect.New(rv.Type().Elem()))
+		}
+		return setValue(rv.Elem(), v)
+	}
+
+	switch v.Kind() {
+	case adt.TopKind, adt.BottomKind:
+		return setValue(rv, v.Eval())
+	case adt.NullKind:
+		return nil
+	case adt.BoolKind:
+		b, err := v.Bool()
+		if err != nil {
+			return err
+		}
+		rv.SetBool(b)
+		return nil
+	case adt.IntKind:
+		b, err := v.Int64()
+		if err != nil {
+			return err
+		}
+		rv.SetInt(b)
+		return nil
+	case adt.BytesKind:
+		b, err := v.Bytes()
+		if err != nil {
+			return err
+		}
+		rv.SetBytes(b)
+		return nil
+	case adt.StringKind:
+		b, err := v.String()
+		if err != nil {
+			return err
+		}
+		rv.SetString(b)
+		return nil
+	case adt.FloatKind:
+		b, err := v.Float64()
+		if err != nil {
+			return err
+		}
+		rv.SetFloat(b)
+	case adt.ListKind, adt.StructKind:
+		// todo need v.Values()
+		bytes, err := v.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		return encodingjson.Unmarshal(bytes, rv.Addr().Interface())
+	}
+
+	return fmt.Errorf("unsupport cue value %s %T", v.Kind(), v)
+}
+
+func adtKindFromReflectType(t reflect.Type) adt.Kind {
+	switch t.Kind() {
+	case reflect.Ptr:
+		return adt.NullKind | adtKindFromReflectType(t.Elem())
+	case reflect.String:
+		return adt.StringKind
+	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
+		return adt.IntKind
+	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+		return adt.IntKind
+	case reflect.Float32, reflect.Float64:
+		return adt.FloatKind
+	case reflect.Bool:
+		return adt.BoolKind
+	case reflect.Array:
+		// byte
+		if t.Elem().Kind() == reflect.Int8 {
+			return adt.BytesKind
+		}
+		return adt.ListKind
+	case reflect.Struct, reflect.Map:
+		return adt.StructKind
+	}
+	return adt.TopKind
+}

--- a/pkg/native/package_test.go
+++ b/pkg/native/package_test.go
@@ -1,0 +1,115 @@
+package native
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/token"
+)
+
+func init() {
+	Register(custom{})
+}
+
+type custom struct {
+}
+
+func (custom) ImportPath() string {
+	return "extension/custom"
+}
+
+func (custom) StringConst() string {
+	return "STRING"
+}
+
+func (custom) CustomFormat(v map[string]interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func Test(t *testing.T) {
+	test := func(pkg, expr string) []*bimport {
+		return []*bimport{{"",
+			[]string{fmt.Sprintf("import %q\n(%s)", pkg, expr)},
+		}}
+	}
+
+	testCases := []struct {
+		instances []*bimport
+		emit      string
+	}{
+		{
+			test("extension/custom", "custom.CustomFormat({ a: 1 })"),
+			`"eyJhIjoxfQ=="`,
+		},
+		{
+			test("extension/custom", "custom.StringConst"),
+			`"STRING"`,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			insts := cue.Build(makeInstances(tc.instances))
+			if err := insts[0].Err; err != nil {
+				t.Fatal(err)
+			}
+			v := insts[0].Value()
+			got := fmt.Sprintf("%+v", v)
+			if got != tc.emit {
+				t.Errorf("\n got: %s\nwant: %s", got, tc.emit)
+			}
+		})
+	}
+}
+
+type bimport struct {
+	path  string // "" means top-level
+	files []string
+}
+
+type builder struct {
+	ctxt    *build.Context
+	imports map[string]*bimport
+}
+
+func (b *builder) load(pos token.Pos, path string) *build.Instance {
+	bi := b.imports[path]
+	if bi == nil {
+		return nil
+	}
+	return b.build(bi)
+}
+
+func makeInstances(insts []*bimport) (instances []*build.Instance) {
+	b := builder{
+		ctxt:    build.NewContext(),
+		imports: map[string]*bimport{},
+	}
+	for _, bi := range insts {
+		if bi.path != "" {
+			b.imports[bi.path] = bi
+		}
+	}
+	for _, bi := range insts {
+		if bi.path == "" {
+			instances = append(instances, b.build(bi))
+		}
+	}
+	return
+}
+
+func (b *builder) build(bi *bimport) *build.Instance {
+	path := bi.path
+	if path == "" {
+		path = "dir"
+	}
+	p := b.ctxt.NewInstance(path, b.load)
+	for i, f := range bi.files {
+		_ = p.AddFile(fmt.Sprintf("file%d.cue", i), f)
+	}
+	_ = p.Complete()
+	return p
+}

--- a/pkg/native/register.go
+++ b/pkg/native/register.go
@@ -1,0 +1,33 @@
+package native
+
+import (
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/internal/core/adt"
+	"cuelang.org/go/internal/core/eval"
+	"cuelang.org/go/internal/core/runtime"
+)
+
+// Register registry custom packages
+func Register(packages ...Package) {
+	for i := range packages {
+		p := packages[i]
+
+		if p == nil {
+			continue
+		}
+
+		ip := newInternalPackage(packages[i])
+
+		if ip == nil {
+			continue
+		}
+
+		importPath := p.ImportPath()
+
+		runtime.RegisterBuiltin(importPath, func(r adt.Runtime) (*adt.Vertex, errors.Error) {
+			ctx := eval.NewContext(r, nil)
+			return ip.MustCompile(ctx, importPath), nil
+		})
+
+	}
+}

--- a/pkg/native/util.go
+++ b/pkg/native/util.go
@@ -1,0 +1,9 @@
+package native
+
+import (
+	"cuelang.org/go/internal/core/runtime"
+)
+
+func IsBuiltinPackage(importPath string) bool {
+	return runtime.SharedRuntime.IsBuiltinPackage(importPath)
+}


### PR DESCRIPTION
When we want to create some custom tool base on cuelang. like a cuelang based [Tanka](http://tanka.dev/)

We need to add custom functions for this tool. 

important usage is the  custom formats, which cue not provided now,
for k8s configmap, like https://jsonnet.org/ref/stdlib.html#manifestIni did

instead of using `*internal.Package`, we could use pure go to registry custom packages.

```golang
package custom

import "cuelang.org/go/pkg/native"

func init() {
	native.Register(custom{})
}

type custom struct {
}

// pkg import path
func (custom) ImportPath() string {
	return "extension/custom"
}

// register as const values, when single value return
func (custom) StringConst() string {
	return "STRING"
}

// register as function, when need parameters, and returns value and error
func (custom) CustomFormat(v map[string]interface{}) ([]byte, error) {
	return json.Marshal(v)
}

// struct support too, and converting rules follow rules `encoding/json`
func (custom) CustomFormatWithStruct(v struct{ Name string `json:"name"` }) ([]byte, error) {
	return json.Marshal(v)
}
```

all inputs and outputs will be converted to cue.Value

Related: https://github.com/cuelang/cue/discussions/446

