### PR TITLE
Enable concrete validation for json to match yaml validation

### DIFF
--- a/pkg/encoding/json/manual.go
+++ b/pkg/encoding/json/manual.go
@@ -119,5 +119,8 @@ func Validate(b []byte, v cue.Value) (bool, error) {
 	if v.Err() != nil {
 		return false, v.Err()
 	}
+	if err = v.Validate(cue.Concrete(true)); err != nil {
+		return false, err
+	}
 	return true, nil
 }


### PR DESCRIPTION
Currently, json.Validate doesn't require values to be concrete which
leads to the non-empty check (something: !="") to be ignored. This
behavior is inconsistent with `cue vet` command [1] and with
yaml.Validate function [2].

This PR will add that concrete validation to json.Validate.

[1]: https://github.com/cuelang/cue/blob/master/cmd/cue/cmd/vet.go#L156
[2]: https://github.com/cuelang/cue/blob/master/pkg/encoding/yaml/manual.go#L114

Signed-off-by: Vu Dinh <vudinh@outlook.com>