### PR TITLE
doc/tutorial/basics: Correct description of comments

### DIFF
--- a/doc/tutorial/basics/0_intro/10_json.txt
+++ b/doc/tutorial/basics/0_intro/10_json.txt
@@ -9,7 +9,7 @@ description = ""
 CUE is a superset of JSON.
 It adds the following conveniences:
 
-- C-style comments,
+- single-line comments,
 - quotes may be omitted from field names without special characters,
 - commas at the end of fields are optional,
 - comma after last element in list is allowed,


### PR DESCRIPTION
As discussed in https://github.com/cuelang/cue/discussions/858, "C-style comments" can be misleading, since the original comment syntax in the C language were multiline-capable `/* comments */`, which CUE does not support. I think describing these as "single-line comments" works well as a correction, since the reader is then drawn to inspect the code samples to observe the `//` syntax.