### PR TITLE
doc/tutorials/basics: fix example of aliases

### DIFF
--- a/doc/tutorial/basics/4_references/30_aliases.txt
+++ b/doc/tutorial/basics/4_references/30_aliases.txt
@@ -6,16 +6,13 @@ title = "Aliases"
 description = ""
 
 -- text.md --
-An alias defines a local macro.
+
+Aliases name values that can be referred to within the scope in which they are declared, and they do not appear in the output.
 
 A typical use case is to provide access to a shadowed field.
 
-Aliases are not members of a struct. They can be referred to only within the
-struct, and they do not appear in the output.
-
 -- alias.cue --
-let A = a  // A is an alias for a
-a: {
+A = a: { // A is an alias for a
     d: 3
 }
 b: {


### PR DESCRIPTION
Fix #948 