### PR TITLE
support disabling field validation by inserting object in to openapi schema

### DIFF
--- a/encoding/openapi/build.go
+++ b/encoding/openapi/build.go
@@ -16,6 +16,7 @@ package openapi
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"path"
 	"regexp"
@@ -181,6 +182,7 @@ func schemas(g *Generator, inst *cue.Instance) (schemas *ast.StructLit, err erro
 }
 
 func (c *buildContext) build(name string, v cue.Value) *ast.StructLit {
+	log.Printf("cue/encoding/openapi: building schema for %v", name)
 	return newCoreBuilder(c).schema(nil, name, v)
 }
 

--- a/encoding/protobuf/cue/cue.proto
+++ b/encoding/protobuf/cue/cue.proto
@@ -9,6 +9,10 @@ option java_package = "org.cuelang.cueproto";
 
 message FieldOptions {
     bool required = 1;
+
+    // Enable this option to treat this field use an unstructured object in the OpenAPI schema for this field.
+    // This is currently required to disable infinite recursion when expanding references with CUE on recursive types.
+    bool disable_openapi_validation = 2;
 }
 
 extend google.protobuf.FieldOptions {

--- a/encoding/protobuf/parse.go
+++ b/encoding/protobuf/parse.go
@@ -783,6 +783,10 @@ func (p *optionParser) parse(options []*proto.Option) {
 			p.required = true
 			// TODO: Dropping comments. Maybe add a dummy tag?
 
+		case "(cue.opt).disable_openapi_validation":
+			// this overrides the type used by the OpenAPI parser to use an ast.Struct, equivalent to a google.protobuf.Struct, which permits all fields.
+			p.field.Value = ast.NewStruct()
+
 		case "(cue.val)":
 			// TODO: set filename and base offset.
 			expr, err := parser.ParseExpr("", o.Constant.Source)


### PR DESCRIPTION
the purpose of this change is to enable the use of recursive fields with Cue reference expansion.

we disable the fields
 
```proto

import "encoding/protobuf/cue/cue.proto";

message RecursiveMessage {
  RecursiveMessage message = 1 [(cue.opt).disable_openapi_validation = true];
  repeated RecursiveMessage messages = 2 [(cue.opt).disable_openapi_validation = true];
}
```

this will yield an openapi schema which treats these fields as having the generic `object` type.  additional work is needed to support unstrucutred fields, which is the addition of `x-kubernetes-preserve-unknown-fields: true` property to openapi schema for the proto fields which supply this option.